### PR TITLE
media keys support, fast forward/rewind, codes instead of keycodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Available keys
 | Key      | Action                      |
 |----------|-----------------------------|
-| Spacebar | Pause/resume video playback |
+| Spacebar, &rtrif;&Verbar; | Pause/resume video playback |
 | F        | Toggle fullscreen           |
 | &uarr;   | Increase playback speed     |
 | &darr;   | Decrease playback speed     |

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@
 | &darr;   | Decrease playback speed     |
 | &rarr;   | Fast forward 10 seconds     |
 | &larr;   | Rewind 10 seconds           |
+| &rtrif;&rtrif; | Fast forward 5 minutes      |
+| &ltrif;&ltrif; | Rewind 5 minutes            |

--- a/src/webex-keys/main.js
+++ b/src/webex-keys/main.js
@@ -13,17 +13,30 @@ const SPEED_ENTRY_CLASS = "setting-a";
 const SLIDER_CLASS = "el-slider__button-wrapper";
 const PLAYHEAD_CLASS = "el-slider__button";
 
-// Keycodes
-const SPACEBAR = 32;
-const ARROW_UP = 38;
-const ARROW_DOWN = 40;
-const ARROW_DX = 39;
-const ARROW_SX = 37;
-const F = 70;
+// Keycodes (deprecated)
+const SPACEBAR_KEY = 32;
+const PAUSE_KEY = 179
+const ARROW_UP_KEY = 38;
+const ARROW_DOWN_KEY = 40;
+const ARROW_DX_KEY = 39;
+const ARROW_SX_KEY = 37;
+const F_KEY = 70;
+
+// Codes
+const SPACEBAR_CODE = "Space";
+const PAUSE_CODE = "MediaPlayPause"
+const ARROW_UP_CODE = "ArrowUp";
+const ARROW_DOWN_CODE = "ArrowDown";
+const ARROW_DX_CODE = "ArrowRight";
+const ARROW_SX_CODE = "ArrowLeft";
+const F_CODE = "KeyF";
+const TRACK_NEXT_CODE = "MediaTrackNext";
+const TRACK_PREVIOUS_CODE = "MediaTrackPrevious";
 
 // Other
 const TIMEOUT = 60;
 const SECONDS = 10;
+const SECONDS_MEDIAKEYS = 300;
 const TIME_SPLIT = ["&nbsp;/&nbsp;", ":"];
 
 // Vars
@@ -35,28 +48,41 @@ document.body.onkeyup = function(event)
         return;
 
     try {
-        
-        switch(event.keyCode)
+        switch( (typeof event.code === "string" && event.code.length) ? event.code : event.keyCode)
         {
-            case SPACEBAR:
+            case SPACEBAR_KEY:
+            case SPACEBAR_CODE:
+            case PAUSE_KEY:
+            case PAUSE_CODE:
                 document.getElementById(PP_BTN).click();
                 break;
-            case F:
+            case F_KEY:
+            case F_CODE:
                 document.getElementById(FULLSCREEN_BTN).click();
                 break;
-            case ARROW_UP:
+            case ARROW_UP_KEY:
+            case ARROW_UP_CODE:
                 if (speed < 2.0)
                     updateSpeed(1);
                 break;
-            case ARROW_DOWN:
+            case ARROW_DOWN_KEY:
+            case ARROW_DOWN_CODE:
                 if (speed > 0.5)
                     updateSpeed(-1);
                 break;
-            case ARROW_DX:
+            case ARROW_DX_KEY:
+            case ARROW_DX_CODE:
                 movePlayhead(1);
                 break;
-            case ARROW_SX:
+            case ARROW_SX_KEY:
+            case ARROW_SX_CODE:
                 movePlayhead(-1);
+                break;
+            case TRACK_NEXT_CODE:
+                movePlayhead(1, SECONDS_MEDIAKEYS);
+                break;
+            case TRACK_PREVIOUS_CODE:
+                movePlayhead(-1, SECONDS_MEDIAKEYS);
                 break;
         }
 
@@ -74,7 +100,7 @@ function clamp(value, min, max)
     return value;
 }
 
-function movePlayhead(direction) 
+function movePlayhead(direction, seconds = SECONDS) 
 {
     try {
 		document.getElementById(SCREEN).dispatchEvent(new MouseEvent("mousemove"));
@@ -84,7 +110,7 @@ function movePlayhead(direction)
 			var i;
 			for (i = 0; i < rawTime.length; i ++)
 				videoLength += parseInt(rawTime[rawTime.length - i - 1]) * Math.pow(60, i);
-			var movement = (document.getElementById(BASE_BAR).getBoundingClientRect().width / videoLength) * SECONDS * direction;
+			var movement = (document.getElementById(BASE_BAR).getBoundingClientRect().width / videoLength) * seconds * direction;
 			var box = document.getElementsByClassName(PLAYHEAD_CLASS)[0].getBoundingClientRect();
 			var coords = [box.x + (box.width / 2), box.y + (box.height / 2)];
 			var slider = document.getElementsByClassName(SLIDER_CLASS)[0];


### PR DESCRIPTION
- added support for _play_/_pause_, _next_ and _previous_ keys
- added a `seconds` parameter to movePlayhead function to specify amount of time to move, so that it is possible to move faster in the timeline with _next_ & _previous_
- integrated `KeyboardEvent.code` (`KeyboardEvent.keyCode` still available but deprecated in standard): if `code` available use `code`, else use `keyCode`